### PR TITLE
1.7.0 Compatibility Initial draft

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="CompilerConfiguration">
-    <bytecodeTargetLevel target="11" />
+    <bytecodeTargetLevel target="17" />
   </component>
 </project>

--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="KotlinJpsPluginSettings">
+    <option name="version" value="2.0.0-Beta3" />
+  </component>
+</project>

--- a/.idea/migrations.xml
+++ b/.idea/migrations.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectMigrations">
+    <option name="MigrateToGradleLocalJavaHome">
+      <set>
+        <option value="$PROJECT_DIR$" />
+      </set>
+    </option>
+  </component>
+</project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="DesignSurface">
     <option name="filePathToZoomLevelMap">
@@ -17,5 +16,5 @@
     <option name="OTHER_OPTIONS" value="--ignore-source-errors" />
     <option name="OPTION_INCLUDE_LIBS" value="true" />
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_11" default="true" project-jdk-name="11" project-jdk-type="JavaSDK" />
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" default="true" project-jdk-name="jbr-17" project-jdk-type="JavaSDK" />
 </project>

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,6 +1,10 @@
 plugins {
     id 'com.android.application'
+    id 'org.jetbrains.kotlin.android'
 }
+
+
+
 
 // Load values from SA properties file.
 def propsFile = rootProject.file('sa.properties')
@@ -29,15 +33,15 @@ android {
             keyPassword props['keyPassword']
         }
     }
-    compileSdkVersion 31
+    compileSdkVersion 33
 
     defaultConfig {
         applicationId "com.millicast.android_java_sdk_sa"
-        minSdkVersion 24
+        minSdkVersion 33
         //noinspection ExpiredTargetSdkVersion
-        targetSdkVersion 28
+        targetSdkVersion 33
         versionCode 11
-        versionName "1.5.2"
+        versionName "1.7.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 
@@ -50,9 +54,10 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
+    namespace 'com.millicast.android_app'
 }
 
 dependencies {
@@ -66,13 +71,15 @@ dependencies {
     implementation 'androidx.navigation:navigation-ui:2.4.1'
     implementation 'androidx.drawerlayout:drawerlayout:1.1.1'
     implementation 'com.google.android.material:material:1.5.0'
+    implementation 'androidx.core:core-ktx:1.10.0'
     testImplementation 'junit:junit:4.+'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
 
     // Add Millicast SDK via one of the methods below.
     // For download via Maven from GitHub Packages:
-    implementation 'com.millicast:millicast-sdk-android:1.5.2'
+    implementation 'com.millicast:millicast-sdk-android:1.7.0'
+    implementation 'io.dolby:promise:2.9.0'
     // For manual addition of AAR file:
     // implementation project(":MillicastSDK")
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -3,14 +3,10 @@ plugins {
     id 'org.jetbrains.kotlin.android'
 }
 
-
-
-
 // Load values from SA properties file.
 def propsFile = rootProject.file('sa.properties')
 def props = new Properties()
 props.load(new FileInputStream(propsFile))
-
 repositories {
     mavenLocal()
     // Millicast SDK via Maven from GitHub Packages
@@ -33,13 +29,13 @@ android {
             keyPassword props['keyPassword']
         }
     }
-    compileSdkVersion 33
+    compileSdkVersion 34
 
     defaultConfig {
         applicationId "com.millicast.android_java_sdk_sa"
         minSdkVersion 33
         //noinspection ExpiredTargetSdkVersion
-        targetSdkVersion 33
+        targetSdkVersion 34
         versionCode 11
         versionName "1.7.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
@@ -72,6 +68,7 @@ dependencies {
     implementation 'androidx.drawerlayout:drawerlayout:1.1.1'
     implementation 'com.google.android.material:material:1.5.0'
     implementation 'androidx.core:core-ktx:1.10.0'
+    implementation 'io.dolby:promise:2.9.0'
     testImplementation 'junit:junit:4.+'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
@@ -79,7 +76,6 @@ dependencies {
     // Add Millicast SDK via one of the methods below.
     // For download via Maven from GitHub Packages:
     implementation 'com.millicast:millicast-sdk-android:1.7.0'
-    implementation 'io.dolby:promise:2.9.0'
     // For manual addition of AAR file:
     // implementation project(":MillicastSDK")
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.millicast.android_app">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.CAMERA" />
 
@@ -30,7 +29,8 @@
         <activity
             android:name=".MainActivity"
             android:label="@string/app_name"
-            android:theme="@style/Theme.Androidapp.NoActionBar">
+            android:theme="@style/Theme.Androidapp.NoActionBar"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/app/src/main/java/com/millicast/android_app/MCTypes.java
+++ b/app/src/main/java/com/millicast/android_app/MCTypes.java
@@ -7,15 +7,15 @@ public class MCTypes {
 
 
     /**
-     * The type of {@link com.millicast.BitrateSettings} referred to.
+     * The type of {@link com.millicast.publishers.BitrateSettings} referred to.
      */
     public enum Bitrate {
         /**
-         * {@link com.millicast.BitrateSettings#minBitrateKbps}
+         * {@link com.millicast.publishers.BitrateSettings#minBitrateKbps}
          */
         MIN,
         /**
-         * {@link com.millicast.BitrateSettings#maxBitrateKbps}
+         * {@link com.millicast.publishers.BitrateSettings#maxBitrateKbps}
          */
         MAX;
     }

--- a/app/src/main/java/com/millicast/android_app/MillicastManager.java
+++ b/app/src/main/java/com/millicast/android_app/MillicastManager.java
@@ -1178,9 +1178,8 @@ public class MillicastManager {
         // If currently subscribing, do not set new audioSourceIndex.
         if (isSubscribing()) {
             logD(TAG, logTag + "NOT setting to " + newValue + " as currently subscribing.");
-            //TODO implement this
-            logD(TAG, logTag + "AudioPlayback:" + "IMPLEMENT THIS");
-            //getAudioSourceStr(audioPlayback.toString(), true));
+            logD(TAG, logTag + "AudioPlayback:" + "");
+            getAudioPlaybackStr(audioPlayback, true);
             return false;
         }
 
@@ -1412,7 +1411,6 @@ public class MillicastManager {
             logD(TAG, logTag + "Flag: " + ndiEnabled + ", Track: Does not exist.");
             return ndiEnabled;
         }
-        //TODO reimplement this
         return ndiEnabled;
     }
 
@@ -1738,26 +1736,27 @@ public class MillicastManager {
 
         publisher.isConnected()
                 .then(connected -> {
-                    if (connected) {
-                        publisher.isPublishing()
-                                .then(publishing -> {
-                                    if (publishing) {
-                                        logD(TAG, logTag + "Not publishing as we are already publishing!");
-                                    } else {
-                                        if (!isAudioVideoCaptured()) {
-                                            logD(TAG, logTag + "Failed! Both audio & video are not captured.");
-                                        } else {
-                                            logD(TAG, logTag + "Trying...");
-                                            startPubMc();
-                                        }
-                                    }
-                                })
-                                .error(e -> {
-                                    logD(TAG, logTag + e.getLocalizedMessage());
-                                });
-                    } else {
-//TODO CLEAN THIS UP
+                    if (!connected) {
+                        logD(TAG, logTag + "Not publishing as we are not connected!");
+                        return;
                     }
+                    publisher.isPublishing()
+                            .then(publishing -> {
+                                if (publishing) {
+                                    logD(TAG, logTag + "Not publishing as we are already publishing!");
+                                    return;
+                                }
+                                if (!isAudioVideoCaptured()) {
+                                    logD(TAG, logTag + "Failed! Both audio & video are not captured.");
+                                    return;
+                                }
+                                logD(TAG, logTag + "Trying...");
+                                startPubMc();
+                            })
+                            .error(e -> {
+                                logD(TAG, logTag + e.getLocalizedMessage());
+                            });
+
                 }).error(e -> {
                     logD(TAG, logTag + e.getLocalizedMessage());
                 });
@@ -2395,7 +2394,7 @@ public class MillicastManager {
      * @return
      */
 
-    //TODO clean this up
+    //TODO clean up
 //    public boolean addMediaTrack(boolean isAudio) {
 //        TrackType kind = TrackType.Audio;
 //        if (!isAudio) {

--- a/app/src/main/java/com/millicast/android_app/PublishFragment.java
+++ b/app/src/main/java/com/millicast/android_app/PublishFragment.java
@@ -23,9 +23,9 @@ import androidx.activity.result.contract.ActivityResultContracts;
 
 import java.util.ArrayList;
 
-import com.millicast.AudioTrack;
 import com.millicast.VideoRenderer;
-import com.millicast.VideoTrack;
+import com.millicast.devices.track.AudioTrack;
+import com.millicast.devices.track.VideoTrack;
 
 import org.webrtc.RendererCommon;
 
@@ -293,17 +293,8 @@ public class PublishFragment extends Fragment {
     }
 
     private void toggleRecordingEnabled(View view){
-        if(mcMan.isRecordingEnabledPub()){
-            if(mcMan.setRecordingEnabled(false)){
-                buttonRecording.setText("Recording:F");
-            };
-
-        }
-        else{
-            if(mcMan.setRecordingEnabled(true)) {
-                buttonRecording.setText("Recording:T");
-            }
-        }
+        logD(TAG, "[Rec]", "Toggling recording...");
+        mcMan.toggleRecordingEnabled();
 
     }
 
@@ -477,6 +468,7 @@ public class PublishFragment extends Fragment {
 
     private void onStopPublishClicked(View view) {
         Log.d(TAG, "Stop Publish clicked.");
+
         mcMan.stopPub();
         setUI();
     }
@@ -668,6 +660,14 @@ public class PublishFragment extends Fragment {
                 buttonPublish.setEnabled(true);
                 break;
         }
+
+        if(mcMan.isRecordingEnabledPub()){
+            buttonRecording.setText("Recording: ON");
+        }
+        else{
+            buttonRecording.setText("Recording: OFF");
+        }
+
         setMuteButtons(true);
     }
 

--- a/app/src/main/java/com/millicast/android_app/SettingsMediaFragment.java
+++ b/app/src/main/java/com/millicast/android_app/SettingsMediaFragment.java
@@ -18,9 +18,9 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
 
-import com.millicast.AudioSource;
-import com.millicast.VideoCapabilities;
-import com.millicast.VideoSource;
+import com.millicast.devices.source.audio.AudioSource;
+import com.millicast.devices.source.video.VideoCapabilities;
+import com.millicast.devices.source.video.VideoSource;
 
 import java.util.ArrayList;
 

--- a/app/src/main/java/com/millicast/android_app/SourceInfo.java
+++ b/app/src/main/java/com/millicast/android_app/SourceInfo.java
@@ -5,8 +5,9 @@ import static com.millicast.android_app.Utils.logD;
 
 import androidx.annotation.NonNull;
 
-import com.millicast.LayerData;
 import com.millicast.Subscriber;
+import com.millicast.subscribers.ProjectionData;
+import com.millicast.subscribers.state.LayerData;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -80,14 +81,14 @@ public class SourceInfo {
     }
 
     /**
-     * Get an ArrayList of {@link com.millicast.Subscriber.ProjectionData} for all the
+     * Get an ArrayList of {@link ProjectionData} for all the
      * audio or video tracks of this MediaInfo.
      *
      * @param mid      The mid onto which this source is requested to be projected onto.
      * @param forAudio
      * @return
      */
-    public ArrayList<Subscriber.ProjectionData> getProjectionData(String mid, boolean forAudio) {
+    public ArrayList<ProjectionData> getProjectionData(String mid, boolean forAudio) {
         String[] trackList = trackIdAudioList;
         String mediaType = "audio";
 
@@ -96,7 +97,7 @@ public class SourceInfo {
             mediaType = "video";
         }
 
-        ArrayList<Subscriber.ProjectionData> result = null;
+        ArrayList<ProjectionData> result = null;
         if (trackList == null || trackList.length < 1) {
             return result;
         }
@@ -104,11 +105,8 @@ public class SourceInfo {
         result = new ArrayList<>();
 
         for (String trackId : trackList) {
-            Subscriber.ProjectionData data = new Subscriber.ProjectionData();
-            data.trackId = trackId;
-            data.media = mediaType;
-            data.mid = mid;
-
+            ProjectionData data = new ProjectionData(trackId,mediaType,mid,null);
+            //data.copy(trackId,mediaType,mid,null);
             result.add(data);
         }
 
@@ -347,19 +345,16 @@ public class SourceInfo {
             name += "N.A.";
             return name;
         }
-
-        name += ld.encodingId;
-        String temStr = "" + ld.temporalLayerId;
-        String spaStr = "" + ld.spatialLayerId;
+        name += ld.getEncodingId();
+        String temStr = "" + ld.getTemporalLayerId();
+        String spaStr = "" + ld.getSpatialLayerId();
         if (longForm) {
             String maxTemLayer = "-";
-            if (ld.maxTemporalLayerId.isPresent()) {
-                maxTemLayer = "" + ld.maxTemporalLayerId.get();
-            }
+            maxTemLayer = "" + ld.getMaxTemporalLayerId();
+
             String maxSpaLayer = "-";
-            if (ld.maxSpatialLayerId.isPresent()) {
-                maxSpaLayer = "" + ld.maxSpatialLayerId.get();
-            }
+
+            maxSpaLayer = "" + ld.getMaxSpatialLayerId();
             temStr += "/" + maxTemLayer;
             spaStr += "/" + maxSpaLayer;
         }

--- a/app/src/main/java/com/millicast/android_app/SwitchHdl.java
+++ b/app/src/main/java/com/millicast/android_app/SwitchHdl.java
@@ -1,6 +1,7 @@
 package com.millicast.android_app;
 
-import com.millicast.VideoSource;
+import com.millicast.devices.source.video.VideoSource;
+import com.millicast.devices.type.SwitchCameraHandler;
 
 import static com.millicast.android_app.Utils.logD;
 
@@ -8,7 +9,7 @@ import static com.millicast.android_app.Utils.logD;
  * Implementation of VideoSource's camera switch listener.
  * This handles camera switch events that allows us to know the outcome and details of camera switching.
  */
-class SwitchHdl implements VideoSource.SwitchCameraHandler {
+class SwitchHdl implements SwitchCameraHandler {
     public static final String TAG = "SwitchHdl";
     private String logTag = "[Video][Source][Cam][Switch][Hdl] ";
 

--- a/app/src/main/java/com/millicast/android_app/VideoSourceEvtHdl.java
+++ b/app/src/main/java/com/millicast/android_app/VideoSourceEvtHdl.java
@@ -2,7 +2,8 @@ package com.millicast.android_app;
 
 import android.os.Handler;
 
-import com.millicast.VideoSource;
+import com.millicast.devices.source.video.VideoSource;
+import com.millicast.devices.type.EventsHandler;
 
 import static com.millicast.android_app.MCStates.*;
 import static com.millicast.android_app.MCTypes.Source.CURRENT;
@@ -13,7 +14,7 @@ import static com.millicast.android_app.Utils.makeSnackbar;
  * Implementation of VideoSource's event listener.
  * This handles camera events that allows us to know the outcome and details of camera operations.
  */
-class VideoSourceEvtHdl implements VideoSource.EventsHandler {
+class VideoSourceEvtHdl implements EventsHandler {
     public static final String TAG = "VidSrcEvtHdl";
 
     private MillicastManager mcMan;

--- a/app/src/main/java/com/millicast/android_app/compat/CompatBase.kt
+++ b/app/src/main/java/com/millicast/android_app/compat/CompatBase.kt
@@ -1,0 +1,49 @@
+package com.millicast.android_app.compat
+
+import android.util.Log
+import com.millicast.publishers.BitrateSettings
+import com.voxeet.promise.Promise
+import com.voxeet.promise.PromiseDebug
+import com.voxeet.promise.solve.Solver
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.MainScope
+import kotlinx.coroutines.async
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import java.util.logging.Logger
+
+open abstract class CompatBase() {
+    val scope = MainScope();
+
+    fun <T> promise(block: suspend () -> T): Promise<T> {
+        return Promise { solver ->
+            run{
+                GlobalScope.launch {
+                    try {
+                        solver.resolve(block());
+                    } catch (err: Throwable) {
+                        solver.reject(err)
+                    }
+                };
+            }
+        };
+    }
+
+
+}
+class CompatBitrateSettings{
+    var disableBWE: Boolean = false
+
+    var maxBitrateKbps: Int? = null;
+
+    var minBitrateKbps : Int? = null
+
+
+    fun get() : BitrateSettings {
+        return BitrateSettings(
+                this.disableBWE,
+                this.maxBitrateKbps,
+                this.minBitrateKbps
+        )
+    }
+}

--- a/app/src/main/java/com/millicast/android_app/compat/PublisherCompat.kt
+++ b/app/src/main/java/com/millicast/android_app/compat/PublisherCompat.kt
@@ -1,0 +1,145 @@
+package com.millicast.android_app.compat
+
+import android.util.Log
+import com.millicast.Core
+import com.millicast.android_app.PubListener
+import com.millicast.clients.ConnectionOptions
+import com.millicast.clients.state.ConnectionState
+import com.millicast.devices.track.AudioTrack
+import com.millicast.devices.track.Track
+import com.millicast.devices.track.VideoTrack
+import com.millicast.publishers.BitrateSettings
+import com.millicast.publishers.Option
+import com.millicast.publishers.PublisherState
+import com.millicast.publishers.state.PublishingState
+import com.millicast.publishers.state.RecordingState
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.launch
+
+
+class PublisherCompat(pubListener: PubListener) : CompatBase() {
+
+    val publisher = Core.createPublisher();
+    val listener = pubListener;
+    var credentials = CompatPublisherCredentials();
+    var options = CompatPublisherOptions();
+    var state = PublisherState();
+    fun connect() =  promise {
+        stateChange();
+        val connOpts = ConnectionOptions(false);
+        publisher.enableStats(true)
+        publisher.setCredentials(credentials.get());
+        onStatsReport()
+        publisher.connect(connectionOptions = connOpts);
+    }
+    fun stateChange() = scope.launch {
+        publisher.state
+                .distinctUntilChanged()
+                .collect { newState: PublisherState ->
+                    if(newState.connectionState != state.connectionState){
+                        when(newState.connectionState){
+                            ConnectionState.Connected -> listener.onConnected()
+                            ConnectionState.Connecting -> {}
+                            ConnectionState.Default -> {}
+                            ConnectionState.Disconnected -> listener.onDisconnected()
+                            ConnectionState.Disconnecting -> {}
+                            is ConnectionState.DisconnectedError -> {
+                                val error = newState.connectionState as ConnectionState.DisconnectedError;
+                                listener.onConnectionError(error.httpCode,error.reason);
+                            }
+                        };
+                    }
+
+                    if(newState.publishingState != state.publishingState){
+                        when(newState.publishingState){
+                            is PublishingState.Error -> {
+                                val error = newState.publishingState as PublishingState.Error
+                                listener.onPublishingError(error.reason)
+                            }
+                            PublishingState.Started -> listener.onPublishing()
+                            PublishingState.Stopped -> {}
+                        }
+                    }
+
+
+                    if(newState.recordingState != state.recordingState){
+                        when(newState.recordingState){
+                            RecordingState.Started -> listener.onRecordingStarted()
+                            RecordingState.StartedFailed -> listener.onFailedToStartRecording()
+                            RecordingState.Stopped -> listener.onRecordingStopped()
+                            RecordingState.StoppedFailed -> listener.onFailedToStopRecording()
+                        }
+                    }
+
+                    if(newState.viewers != state.viewers){
+                        listener.onViewerCount(newState.viewers);
+                    }
+                    state = newState;
+                }
+    }
+
+    fun getStats(interval: Boolean) = promise { publisher.enableStats(interval) }
+
+    fun isConnected() = promise { publisher.isConnected }
+
+    fun isRecording() = state.recordingState == RecordingState.Started;
+
+    fun release() = publisher.release();
+    fun addTrack(audioTrackPub: AudioTrack) = promise { publisher.addTrack(audioTrackPub as Track); }
+
+    fun addTrack(videoTrackPub: VideoTrack) = promise { publisher.addTrack(videoTrackPub as Track) }
+
+    fun publish() = promise {
+        publisher.setCredentials(credentials.get())
+        publisher.publish(options.get());
+    }
+
+    fun startRecording() = promise { publisher.recording.start() }
+
+    fun stopRecording() = promise { publisher.recording.stop() }
+
+    fun unpublish() = promise { publisher.unpublish() }
+
+    fun isPublishing() = promise { publisher.isPublishing }
+
+    fun onStatsReport() = scope.launch {
+        publisher.rtcStatsReport.distinctUntilChanged().collect{ report -> listener.onStatsReport(report) }
+    }
+}
+
+class CompatPublisherOptions(){
+    var stereo : Boolean = true;
+    var recordStream = false;
+    var sourceId = "";
+    var bitrateSettings = CompatBitrateSettings();
+    var audioCodec = "";
+    var videoCodec = ""
+
+    fun get() : Option {
+        return Option(
+                stereo = this.stereo,
+                recordStream = this.recordStream,
+                sourceId = null,
+                bitrateSettings = BitrateSettings(
+                        minBitrateKbps = bitrateSettings.minBitrateKbps,
+                        maxBitrateKbps = bitrateSettings.maxBitrateKbps,
+                        disableBWE = bitrateSettings.disableBWE
+                ),
+                videoCodec = this.videoCodec,
+                audioCodec = this.audioCodec
+        )
+    }
+}
+
+class CompatPublisherCredentials() {
+    var apiUrl = "";
+    var streamName = "";
+    var token = "";
+
+    fun get() = com.millicast.publishers.Credential(
+            streamName = this.streamName,
+            token = this.token,
+            apiUrl = this.apiUrl,
+
+    );
+}

--- a/app/src/main/java/com/millicast/android_app/compat/SubscriberCompat.kt
+++ b/app/src/main/java/com/millicast/android_app/compat/SubscriberCompat.kt
@@ -1,0 +1,163 @@
+package com.millicast.android_app.compat
+
+import android.util.Log
+import com.millicast.Core
+import com.millicast.clients.state.ConnectionState
+import com.millicast.devices.track.AudioTrack
+import com.millicast.devices.track.TrackType
+import com.millicast.devices.track.VideoTrack
+import com.millicast.subscribers.Credential
+import com.millicast.subscribers.Option
+import com.millicast.subscribers.ProjectionData
+import com.millicast.subscribers.SubscriberListener
+import com.millicast.subscribers.SubscriberState
+import com.millicast.subscribers.state.ActivityStream
+import com.millicast.subscribers.state.LayerData
+import com.millicast.subscribers.state.SubscriptionState
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.launch
+import java.util.Optional
+
+
+class SubscriberCompat(subscriberListener: SubscriberListener) : CompatBase() {
+    val subscriber = Core.createSubscriber();
+    val listener = subscriberListener;
+    var credentials = CompatSubscriberCreds();
+    var options = CompatSubscriberOptions();
+    var state = SubscriberState();
+    fun connect() =  promise {
+        stateChange();
+        activityChange()
+        layersChange()
+        onTrack();
+        onLayers();
+        onVad();
+        subscriber.setCredentials(credentials.get());
+        subscriber.connect()
+    }
+    fun stateChange() = scope.launch {
+        // given a known subscriber object
+        subscriber.state
+                .distinctUntilChanged()
+                .collect { newState: SubscriberState ->
+                    // and then perform any operation that fit our logic
+                    // here just logging those
+                    Log.d("[Kotlin]", "new state received $newState")
+                    if(!newState.connectionState.equals(state.connectionState)){
+                        when (newState.connectionState){
+                            ConnectionState.Connected -> listener.onConnected()
+                            ConnectionState.Connecting -> {}
+                            ConnectionState.Default -> {}
+                            ConnectionState.Disconnected -> listener.onDisconnected()
+                            is ConnectionState.DisconnectedError -> {
+                                val error = newState.connectionState as ConnectionState.DisconnectedError;
+                                listener.onConnectionError(error.httpCode,error.reason);
+                            }
+                            ConnectionState.Disconnecting -> {}
+                        }
+                    }
+                    if(newState.subscriptionState != state.subscriptionState){
+                        when(newState.subscriptionState){
+                            SubscriptionState.Default -> {}
+                            is SubscriptionState.Error -> {
+                                val error = newState.subscriptionState as SubscriptionState.Error;
+                                listener.onSubscribedError(error.reason);
+                            }
+                            SubscriptionState.Stopped -> listener.onStopped()
+                            SubscriptionState.Subscribed -> listener.onSubscribed()
+                        }
+                    }
+
+                    if (newState.viewers != state.viewers){
+                        listener.onViewerCount(newState.viewers);
+                    }
+
+                    state = newState;
+                }
+    }
+
+    fun activityChange() = scope.launch {
+        subscriber.activity.distinctUntilChanged().collect{
+            newActivity ->
+            when(newActivity){
+                is ActivityStream.Active -> newActivity.sourceId?.let { Optional.of(it) }?.let { listener.onActive(newActivity.streamId,newActivity.track, it) }
+                is ActivityStream.Inactive -> newActivity.sourceId?.let { Optional.of(it) }?.let { listener.onInactive(newActivity.streamId,Optional.of(newActivity.sourceId!!)) }
+            }
+    }
+    }
+
+    fun layersChange() = scope.launch {
+        subscriber.layers.distinctUntilChanged().collect{
+            newLayers ->
+                listener.onLayers(newLayers.mid,newLayers.activeLayers,newLayers.inactiveLayersEncodingIds)
+        }
+    }
+
+    private fun onTrack() = scope.launch {
+            subscriber.track.collect() { holder ->
+                if(holder.track.kind.equals(TrackType.Audio))
+                    listener.onTrack(holder.track as AudioTrack, Optional.of(holder.mid.orEmpty()));
+                if(holder.track.kind.equals(TrackType.Video))
+                    listener.onTrack(holder.track as VideoTrack, Optional.of(holder.mid.orEmpty()));
+            }
+        }
+
+    private fun onLayers() = scope.launch {
+        subscriber.layers.distinctUntilChanged().collect{
+            layer ->
+            listener.onLayers(layer.mid,layer.activeLayers, layer.inactiveLayersEncodingIds)
+        }
+    }
+
+    fun onVad() = scope.launch {
+        subscriber.vad.distinctUntilChanged().collect{
+            vad ->
+            vad.sourceId?.let { Optional.of(it) }?.let { listener.onVad(vad.mid, it) }
+        }
+    }
+    fun select(layerData: LayerData) = promise { subscriber.select(layerData) }
+
+    fun project(sourceId: String, projectionData: ArrayList<ProjectionData?>) =
+            promise {subscriber.project(sourceId,projectionData)}
+
+    fun addRemoteTrack(trackType: TrackType) = promise{ subscriber.addRemoteTrack(trackType) }
+
+    fun getMid(trackId: String) = promise { subscriber.getMid(trackId) }
+
+    fun getStats(interval: Boolean) = promise { subscriber.enableStats(interval) }
+
+    fun isConnected() = promise { subscriber.isConnected }
+
+    fun release() = subscriber.release();
+
+    fun subscribe() = promise {subscriber.subscribe(options.get())}
+
+    fun unsubscribe() = promise { subscriber.unsubscribe() }
+
+    fun isSubscribed() = subscriber.isSubscribed;
+}
+
+class CompatSubscriberOptions(){
+    var stereo : Boolean = true;
+    fun get() : Option {
+        return Option(
+                stereo = this.stereo
+        )
+    }
+}
+
+
+class CompatSubscriberCreds() {
+    var apiUrl = "";
+    var accountId = ""
+    var streamName = "";
+    var token = "";
+
+    fun get() = Credential(
+            streamName=this.streamName,
+            accountId = this.accountId,
+            token = if (this.token.equals("")) null else this.token,
+            apiUrl = this.apiUrl
+    );
+}

--- a/app/src/main/java/com/millicast/android_app/compat/SubscriberCompat.kt
+++ b/app/src/main/java/com/millicast/android_app/compat/SubscriberCompat.kt
@@ -29,7 +29,6 @@ class SubscriberCompat(subscriberListener: SubscriberListener) : CompatBase() {
     fun connect() =  promise {
         stateChange();
         activityChange()
-        layersChange()
         onTrack();
         onLayers();
         onVad();
@@ -87,12 +86,6 @@ class SubscriberCompat(subscriberListener: SubscriberListener) : CompatBase() {
     }
     }
 
-    fun layersChange() = scope.launch {
-        subscriber.layers.distinctUntilChanged().collect{
-            newLayers ->
-                listener.onLayers(newLayers.mid,newLayers.activeLayers,newLayers.inactiveLayersEncodingIds)
-        }
-    }
 
     private fun onTrack() = scope.launch {
             subscriber.track.collect() { holder ->

--- a/build.gradle
+++ b/build.gradle
@@ -1,11 +1,16 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
+    ext {
+        kotlin_version = '2.0.0-Beta3'
+    }
     repositories {
         google()
         jcenter()
+        mavenLocal()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.2.1'
+        classpath 'com.android.tools.build:gradle:8.2.2'
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
@@ -16,6 +21,7 @@ allprojects {
     repositories {
         google()
         jcenter()
+        mavenLocal()
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-bin.zip

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,4 +1,23 @@
+pluginManagement {
+    buildscript {
+        repositories {
+            mavenCentral()
+            maven {
+                // r8 maven
+                url = uri("https://storage.googleapis.com/r8-releases/raw")
+            }
+        }
+        dependencies {
+            // r8 version
+            classpath("com.android.tools:r8:8.2.16-dev")
+        }
+    }
+}
+
+
+
 include ':MillicastSDK'
 include ':AndroidSDK'
 include ':app'
 rootProject.name = "android-app"
+


### PR DESCRIPTION
- Add a Kotlin compatibility layer required to use the 1.7.0 Millicast SDK
- Refactor the publisher/subscriber methods in the `MillicastManager` to work asynchronously with Promises
- Fix imports to match the new package paths in  1.7.0 

This is the initial working version, more cleanups are required, but the PR is already quite large, so after this one a net one will come with, among others
- Some synchronous methods that used to return `boolean` now work async and return `void`, to be fixed
- NDI support temporarily not working, to be fixed
